### PR TITLE
[dev128] fix DQMStore: WARNING: cannot extract object '<nHits>CPUvsGPU RecHits

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,26 @@
 # CMS DQMGUI
 
+## How to test PR 
+For example, we need to test PR to GUI. Then, merge PR to the dev128 branch and create a tag from this branch.
+Setup enviroment:
+```
+ssh cmsdev20.cern.ch
+git clone git@github.com:cms-sw/cmsdist -b comp_gcc630
+git clone git@github.com:cms-sw/pkgtools -b V00-33-XX
+```
+update cmsdist/dqmgui.spec to use tag from dev128 branch and change the tag number (first line). Compile, build:
+```
+./pkgtools/cmsBuild --repo comp -a slc7_amd64_gcc630 -i w -j 10 build dqmgui
+```
+probably, after this it is possible to move executables to P5 machine.
+
+## Update Offline DQM GUI:  
+Make and merge a PR into branch index128. Create a tag in dqmgui repo. Change GUI version in cmsdist (first line): 
+`https://github.com/cms-sw/cmsdist/blob/comp_gcc630/dqmgui.spec` in branch comp_gcc630. 
+Ask for the new version (cmsdist and dmwm/deployment PRs) to be added to the next CMSWEB release. 
+Eg.: https://gitlab.cern.ch/cms-http-group/doc/issues/207  
+If you need a release urgently, ask for it to be tagged with an HG tag: (the new Lina) muhammad.imran@cern.ch  dmwm/deployment PRs can be merged as patches during deployment (Online)
+
 ## Continuous integration
 
 [Jenkins server](https://cms-dqmgui-ci.web.cern.ch/job/dqmgui-github/) uses `Jenkinsfile` to build.

--- a/src/cpp/DQM/DQMNet.cc
+++ b/src/cpp/DQM/DQMNet.cc
@@ -322,6 +322,14 @@ DQMNet::reinstateObject(DQMStore *store, Object &o)
     obj = store->book1S(name, dynamic_cast<TH1S *>(o.object));
     break;
 
+  case DQM_PROP_TYPE_TH1I:
+    obj = store->book1I(name, dynamic_cast<TH1I *>(o.object));
+    break;
+
+  case DQM_PROP_TYPE_TH2I:
+    obj = store->book1I(name, dynamic_cast<TH2I *>(o.object));
+    break;
+
   case DQM_PROP_TYPE_TH1D:
     obj = store->book1DD(name, dynamic_cast<TH1D *>(o.object));
     break;

--- a/src/cpp/DQM/DQMStore.cc
+++ b/src/cpp/DQM/DQMStore.cc
@@ -976,10 +976,16 @@ DQMStore::book1D(const std::string &dir, const std::string &name, TH1F *h)
 }
 
 /// Book 1D histogram based on TH1S.
-MonitorElement *
-DQMStore::book1S(const std::string &dir, const std::string &name, TH1S *h)
-{
+MonitorElement * DQMStore::book1S(const std::string &dir, const std::string &name, TH1S *h) {
   return book(dir, name, "book1S", MonitorElement::DQM_KIND_TH1S, h, collate1S);
+}
+
+MonitorElement * DQMStore::book1I(const std::string &dir, const std::string &name, TH1I *h) {
+  return book(dir, name, "book1I", MonitorElement::DQM_KIND_TH1I, h, collate1I);
+}
+
+MonitorElement * DQMStore::book2I(const std::string &dir, const std::string &name, TH2I *h) {
+  return book(dir, name, "book2I", MonitorElement::DQM_KIND_TH2I, h, collate2I);
 }
 
 /// Book 1D histogram based on TH1D.
@@ -1006,19 +1012,29 @@ DQMStore::book1D(const std::string &name, const std::string &title,
 }
 
 /// Book 1S histogram.
-MonitorElement *
-DQMStore::book1S(const char *name, const char *title,
-                 int nchX, double lowX, double highX)
-{
+MonitorElement * DQMStore::book1S(const char *name, const char *title, int nchX, double lowX, double highX) {
   return book1S(pwd_, name, new TH1S(name, title, nchX, lowX, highX));
 }
 
+MonitorElement * DQMStore::book1I(const char *name, const char *title, int nchX, double lowX, double highX) {
+  return book1I(pwd_, name, new TH1I(name, title, nchX, lowX, highX));
+}
+
+MonitorElement * DQMStore::book2I(const char *name, const char *title, int nchX, double lowX, double highX) {
+  return book2I(pwd_, name, new TH2I(name, title, nchX, lowX, highX));
+}
+
 /// Book 1S histogram.
-MonitorElement *
-DQMStore::book1S(const std::string &name, const std::string &title,
-                 int nchX, double lowX, double highX)
-{
+MonitorElement * DQMStore::book1S(const std::string &name, const std::string &title, int nchX, double lowX, double highX) {
   return book1S(pwd_, name, new TH1S(name.c_str(), title.c_str(), nchX, lowX, highX));
+}
+
+MonitorElement * DQMStore::book1I(const std::string &name, const std::string &title, int nchX, double lowX, double highX) {
+  return book1I(pwd_, name, new TH1I(name.c_str(), title.c_str(), nchX, lowX, highX));
+}
+
+MonitorElement * DQMStore::book2I(const std::string &name, const std::string &title, int nchX, double lowX, double highX) {
+  return book2I(pwd_, name, new TH2I(name.c_str(), title.c_str(), nchX, lowX, highX));
 }
 
 /// Book 1S histogram.
@@ -1068,17 +1084,29 @@ DQMStore::book1D(const std::string &name, TH1F *source)
 }
 
 /// Book 1S histogram by cloning an existing histogram.
-MonitorElement *
-DQMStore::book1S(const char *name, TH1S *source)
-{
+MonitorElement * DQMStore::book1S(const char *name, TH1S *source) {
   return book1S(pwd_, name, static_cast<TH1S *>(source->Clone(name)));
 }
 
+MonitorElement * DQMStore::book1I(const char *name, TH1I *source) {
+  return book1I(pwd_, name, static_cast<TH1I *>(source->Clone(name)));
+}
+
+MonitorElement * DQMStore::book2I(const char *name, TH2I *source) {
+  return book2I(pwd_, name, static_cast<TH2I *>(source->Clone(name)));
+}
+
 /// Book 1S histogram by cloning an existing histogram.
-MonitorElement *
-DQMStore::book1S(const std::string &name, TH1S *source)
-{
+MonitorElement * DQMStore::book1S(const std::string &name, TH1S *source){
   return book1S(pwd_, name, static_cast<TH1S *>(source->Clone(name.c_str())));
+}
+
+MonitorElement * DQMStore::book1I(const std::string &name, TH1I *source){
+  return book1I(pwd_, name, static_cast<TH1I *>(source->Clone(name.c_str())));
+}
+
+MonitorElement * DQMStore::book2I(const std::string &name, TH2I *source){
+  return book2I(pwd_, name, static_cast<TH2I *>(source->Clone(name.c_str())));
 }
 
 /// Book 1D double histogram by cloning an existing histogram.
@@ -1564,12 +1592,9 @@ DQMStore::collate1D(MonitorElement *me, TH1F *h, unsigned verbose)
     me->getTH1F()->Add(h);
 }
 
-void
-DQMStore::collate1S(MonitorElement *me, TH1S *h, unsigned verbose)
-{
-  if (checkBinningMatches(me,h,verbose))
-    me->getTH1S()->Add(h);
-}
+void DQMStore::collate1S(MonitorElement *me, TH1S *h, unsigned verbose) { if (checkBinningMatches(me,h,verbose)) me->getTH1S()->Add(h); }
+void DQMStore::collate1I(MonitorElement *me, TH1I *h, unsigned verbose) { if (checkBinningMatches(me,h,verbose)) me->getTH1I()->Add(h); }
+void DQMStore::collate2I(MonitorElement *me, TH2I *h, unsigned verbose) { if (checkBinningMatches(me,h,verbose)) me->getTH2I()->Add(h); }
 
 void
 DQMStore::collate1DD(MonitorElement *me, TH1D *h, unsigned verbose)
@@ -2178,6 +2203,28 @@ DQMStore::extract(TObject *obj, const std::string &dir,
       me->copyFrom(h);
     else if (isCollateME(me) || collateHistograms)
       collate1S(me, h, verbose_);
+    refcheck = me;
+  }
+  else if (TH1I *h = dynamic_cast<TH1I *>(obj))
+  {
+    MonitorElement *me = findObject(dir, h->GetName());
+    if (! me)
+      me = book1I(dir, h->GetName(), (TH1I *) h->Clone());
+    else if (overwrite)
+      me->copyFrom(h);
+    else if (isCollateME(me) || collateHistograms)
+      collate1I(me, h, verbose_);
+    refcheck = me;
+  }
+  else if (TH2I *h = dynamic_cast<TH2I *>(obj))
+  {
+    MonitorElement *me = findObject(dir, h->GetName());
+    if (! me)
+      me = book2I(dir, h->GetName(), (TH2I *) h->Clone());
+    else if (overwrite)
+      me->copyFrom(h);
+    else if (isCollateME(me) || collateHistograms)
+      collate2I(me, h, verbose_);
     refcheck = me;
   }
   else if (TH1D *h = dynamic_cast<TH1D *>(obj))
@@ -3468,6 +3515,16 @@ DQMStore::scaleElements(void)
       case MonitorElement::DQM_KIND_TH1D:
         {
           me.getTH1D()->Scale(factor);
+          break;
+        }
+      case MonitorElement::DQM_KIND_TH1I:
+        {
+          me.getTH1I()->Scale(factor);
+          break;
+        }
+      case MonitorElement::DQM_KIND_TH2I:
+        {
+          me.getTH2I()->Scale(factor);
           break;
         }
       case MonitorElement::DQM_KIND_TH2F:

--- a/src/cpp/DQM/DQMStore.h
+++ b/src/cpp/DQM/DQMStore.h
@@ -34,6 +34,8 @@ class TH1;
 class TObjString;
 class TH1F;
 class TH1S;
+class TH1I;
+class TH2I;
 class TH1D;
 class TH2F;
 class TH2S;
@@ -120,6 +122,16 @@ class DQMStore
     template <typename... Args>
     MonitorElement * book1S(Args && ... args) {
       return owner_->book1S(std::forward<Args>(args)...);
+    }
+
+    template <typename... Args>
+    MonitorElement * book1I(Args && ... args) {
+      return owner_->book1I(std::forward<Args>(args)...);
+    }
+
+    template <typename... Args>
+    MonitorElement * book2I(Args && ... args) {
+      return owner_->book2I(std::forward<Args>(args)...);
     }
 
     // for the supported syntaxes, see the declarations of DQMStore::book1DD
@@ -328,20 +340,22 @@ class DQMStore
   MonitorElement *              book1D       (const char *name, TH1F *h);
   MonitorElement *              book1D       (const std::string &name, TH1F *h);
 
-  MonitorElement *              book1S       (const char *name,
-                                              const char *title,
-                                              int nchX, double lowX, double highX);
-  MonitorElement *              book1S       (const std::string &name,
-                                              const std::string &title,
-                                              int nchX, double lowX, double highX);
-  MonitorElement *              book1S       (const char *name,
-                                              const char *title,
-                                              int nchX, const float *xbinsize);
-  MonitorElement *              book1S       (const std::string &name,
-                                              const std::string &title,
-                                              int nchX, const float *xbinsize);
+  MonitorElement *              book1S       (const char *name, const char *title, int nchX, double lowX, double highX);
+  MonitorElement *              book1S       (const std::string &name, const std::string &title, int nchX, double lowX, double highX);
+  MonitorElement *              book1S       (const char *name, const char *title, int nchX, const float *xbinsize);
+  MonitorElement *              book1S       (const std::string &name, const std::string &title, int nchX, const float *xbinsize);
   MonitorElement *              book1S       (const char *name, TH1S *h);
   MonitorElement *              book1S       (const std::string &name, TH1S *h);
+
+  MonitorElement *              book1I(const char *name, const char *title, int nchX, double lowX, double highX);
+  MonitorElement *              book1I(const std::string &name, const std::string &title, int nchX, double lowX, double highX);
+  MonitorElement *              book1I(const char *name, TH1I *source);
+  MonitorElement *              book1I(const std::string &name, TH1I *source);
+
+  MonitorElement *              book2I(const char *name, const char *title, int nchX, double lowX, double highX);
+  MonitorElement *              book2I(const std::string &name, const std::string &title, int nchX, double lowX, double highX);
+  MonitorElement *              book2I(const char *name, TH1I *source);
+  MonitorElement *              book2I(const std::string &name, TH1I *source);
 
   MonitorElement *              book1DD       (const char *name,
                                                const char *title,
@@ -655,6 +669,8 @@ class DQMStore
   MonitorElement *              bookString(const std::string &dir, const std::string &name, const std::string &value);
   MonitorElement *              book1D(const std::string &dir, const std::string &name, TH1F *h);
   MonitorElement *              book1S(const std::string &dir, const std::string &name, TH1S *h);
+  MonitorElement *              book1I(const std::string &dir, const std::string &name, TH1I *h);
+  MonitorElement *              book2I(const std::string &dir, const std::string &name, TH2I *h);
   MonitorElement *              book1DD(const std::string &dir, const std::string &name, TH1D *h);
   MonitorElement *              book2D(const std::string &dir, const std::string &name, TH2F *h);
   MonitorElement *              book2S(const std::string &dir, const std::string &name, TH2S *h);
@@ -667,6 +683,8 @@ class DQMStore
 
   static void                   collate1D(MonitorElement *me, TH1F *h, unsigned verbose);
   static void                   collate1S(MonitorElement *me, TH1S *h, unsigned verbose);
+  static void                   collate1I(MonitorElement *me, TH1I *h, unsigned verbose);
+  static void                   collate2I(MonitorElement *me, TH2I *h, unsigned verbose);
   static void                   collate1DD(MonitorElement *me, TH1D *h, unsigned verbose);
   static void                   collate2D(MonitorElement *me, TH2F *h, unsigned verbose);
   static void                   collate2S(MonitorElement *me, TH2S *h, unsigned verbose);

--- a/src/cpp/DQM/MonitorElement.h
+++ b/src/cpp/DQM/MonitorElement.h
@@ -6,6 +6,8 @@
 # include "TF1.h"
 # include "TH1F.h"
 # include "TH1S.h"
+# include "TH1I.h"
+# include "TH2I.h"
 # include "TH1D.h"
 # include "TH2F.h"
 # include "TH2S.h"
@@ -341,6 +343,8 @@ public:
   TH1 *getTH1(void) const;
   TH1F *getTH1F(void) const;
   TH1S *getTH1S(void) const;
+  TH1I *getTH1I(void) const;
+  TH2I *getTH2I(void) const;
   TH1D *getTH1D(void) const;
   TH2F *getTH2F(void) const;
   TH2S *getTH2S(void) const;
@@ -353,6 +357,8 @@ public:
   TH1 *getRefTH1(void) const;
   TH1F *getRefTH1F(void) const;
   TH1S *getRefTH1S(void) const;
+  TH1I *getRefTH1I(void) const;
+  TH2I *getRefTH2I(void) const;
   TH1D *getRefTH1D(void) const;
   TH2F *getRefTH2F(void) const;
   TH2S *getRefTH2S(void) const;

--- a/src/cpp/DQM/QTest.cc
+++ b/src/cpp/DQM/QTest.cc
@@ -72,6 +72,24 @@ float Comp2RefEqualH::runTest(const MonitorElement*me)
     ref_ = me->getRefTH1S(); //access Ref hiso 
     if (nbins != nbinsref) return -1;
   } 
+  //-- TH1I
+  else if (me->kind()==MonitorElement::DQM_KIND_TH1I)
+  { 
+    nbins = me->getTH1I()->GetXaxis()->GetNbins(); 
+    nbinsref = me->getRefTH1I()->GetXaxis()->GetNbins();
+    h  = me->getTH1I(); // access Test histo
+    ref_ = me->getRefTH1I(); //access Ref hiso 
+    if (nbins != nbinsref) return -1;
+  } 
+  //-- TH2I
+  else if (me->kind()==MonitorElement::DQM_KIND_TH2I)
+  { 
+    nbins = me->getTH1I()->GetXaxis()->GetNbins(); 
+    nbinsref = me->getRefTH2I()->GetXaxis()->GetNbins();
+    h  = me->getTH2I(); // access Test histo
+    ref_ = me->getRefTH2I(); //access Ref hiso 
+    if (nbins != nbinsref) return -1;
+  } 
   //-- TH1D
   else if (me->kind()==MonitorElement::DQM_KIND_TH1D)
   { 
@@ -183,6 +201,18 @@ float Comp2RefChi2::runTest(const MonitorElement *me)
   { 
     h = me->getTH1S(); // access Test histo
     ref_ = me->getRefTH1S(); //access Ref histo
+  } 
+  //-- TH1I
+  else if (me->kind()==MonitorElement::DQM_KIND_TH1I)
+  { 
+    h = me->getTH1I(); // access Test histo
+    ref_ = me->getRefTH1I(); //access Ref histo
+  } 
+  //-- TH2I
+  else if (me->kind()==MonitorElement::DQM_KIND_TH2I)
+  { 
+    h = me->getTH2I(); // access Test histo
+    ref_ = me->getRefTH2I(); //access Ref histo
   } 
   //-- TH1D
   else if (me->kind()==MonitorElement::DQM_KIND_TH1D)
@@ -497,6 +527,10 @@ float ContentsXRange::runTest(const MonitorElement*me)
   {
     h = me->getTH1S();
   } 
+  else if ( me->kind()==MonitorElement::DQM_KIND_TH1I ) 
+  {
+    h = me->getTH1I();
+  } 
   // -- TH1D
   else if ( me->kind()==MonitorElement::DQM_KIND_TH1D ) 
   {
@@ -566,6 +600,10 @@ float ContentsYRange::runTest(const MonitorElement*me)
   { 
     h = me->getTH1S(); //access Test histo
   } 
+  else if (me->kind()==MonitorElement::DQM_KIND_TH1I) 
+  { 
+    h = me->getTH1I(); //access Test histo
+  } 
   else if (me->kind()==MonitorElement::DQM_KIND_TH1D) 
   { 
     h = me->getTH1D(); //access Test histo
@@ -575,7 +613,7 @@ float ContentsYRange::runTest(const MonitorElement*me)
     if (verbose_>0) 
       std::cout << "QTest:ContentsYRange" 
                 << " ME " << me->getFullname() 
-                << " does not contain TH1F/TH1S/TH1D, exiting\n"; 
+                << " does not contain TH1F/TH1S/TH1I/TH1D, exiting\n"; 
     return -1;
   } 
 
@@ -770,6 +808,11 @@ float NoisyChannel::runTest(const MonitorElement *me)
     nbins = me->getTH1S()->GetXaxis()->GetNbins(); 
     h  = me->getTH1S(); // access Test histo
   } 
+  else if (me->kind()==MonitorElement::DQM_KIND_TH1I)
+  { 
+    nbins = me->getTH1I()->GetXaxis()->GetNbins(); 
+    h  = me->getTH1I(); // access Test histo
+  } 
   //-- TH1D
   else if (me->kind()==MonitorElement::DQM_KIND_TH1D)
   { 
@@ -789,6 +832,12 @@ float NoisyChannel::runTest(const MonitorElement *me)
     nbins = me->getTH2S()->GetXaxis()->GetNbins() *
             me->getTH2S()->GetYaxis()->GetNbins();
     h  = me->getTH2S(); // access Test histo
+  } 
+  else if (me->kind()==MonitorElement::DQM_KIND_TH2I)
+  { 
+    nbins = me->getTH2I()->GetXaxis()->GetNbins() *
+            me->getTH2I()->GetYaxis()->GetNbins();
+    h  = me->getTH2I(); // access Test histo
   } 
   //-- TH2
   else if (me->kind()==MonitorElement::DQM_KIND_TH2D)
@@ -1166,6 +1215,10 @@ float MeanWithinExpected::runTest(const MonitorElement *me )
   { 
     h = me->getTH1S(); //access Test histo
   }
+  else if (me->kind()==MonitorElement::DQM_KIND_TH1I) 
+  { 
+    h = me->getTH1I(); //access Test histo
+  }
   else if (me->kind()==MonitorElement::DQM_KIND_TH1D) 
   { 
     h = me->getTH1D(); //access Test histo
@@ -1174,7 +1227,7 @@ float MeanWithinExpected::runTest(const MonitorElement *me )
     if (verbose_>0) 
       std::cout << "QTest:MeanWithinExpected"
                 << " ME " << me->getFullname() 
-                << " does not contain TH1F/TH1S/TH1D, exiting\n"; 
+                << " does not contain TH1F/TH1S/TH1D/TH1I, exiting\n"; 
     return -1;
   } 
  

--- a/src/cpp/DQM/index.cc
+++ b/src/cpp/DQM/index.cc
@@ -481,6 +481,7 @@ classifyMonitorElement(DQMStore & /* store */,
 
   case MonitorElement::DQM_KIND_TH1F:
   case MonitorElement::DQM_KIND_TH1S:
+  case MonitorElement::DQM_KIND_TH1I:
   case MonitorElement::DQM_KIND_TH1D:
   case MonitorElement::DQM_KIND_TH2F:
   case MonitorElement::DQM_KIND_TH2S:
@@ -1129,8 +1130,8 @@ extend(VisDQMIndex &ix,
 	    {
 	    case MonitorElement::DQM_KIND_TH1F:
 	    case MonitorElement::DQM_KIND_TH1S:
-	    case MonitorElement::DQM_KIND_TH1D:
 	    case MonitorElement::DQM_KIND_TH1I:
+	    case MonitorElement::DQM_KIND_TH1D:
 	    case MonitorElement::DQM_KIND_TH2F:
 	    case MonitorElement::DQM_KIND_TH2S:
 	    case MonitorElement::DQM_KIND_TH2D:
@@ -1359,12 +1360,12 @@ readFileStream(FileInfo &fi,
       break;
     case MonitorElement::DQM_KIND_TH1F:
     case MonitorElement::DQM_KIND_TH1S:
-    case MonitorElement::DQM_KIND_TH1D:
     case MonitorElement::DQM_KIND_TH1I:
+    case MonitorElement::DQM_KIND_TH1D:
     case MonitorElement::DQM_KIND_TH2F:
     case MonitorElement::DQM_KIND_TH2S:
-    case MonitorElement::DQM_KIND_TH2D:
     case MonitorElement::DQM_KIND_TH2I:
+    case MonitorElement::DQM_KIND_TH2D:
     case MonitorElement::DQM_KIND_TH3F:
     case MonitorElement::DQM_KIND_TPROFILE:
     case MonitorElement::DQM_KIND_TPROFILE2D:
@@ -1486,12 +1487,12 @@ readFileStreamProtocolBuffer(FileInfo &fi,
       break;
     case MonitorElement::DQM_KIND_TH1F:
     case MonitorElement::DQM_KIND_TH1S:
-    case MonitorElement::DQM_KIND_TH1D:
     case MonitorElement::DQM_KIND_TH1I:
+    case MonitorElement::DQM_KIND_TH1D:
     case MonitorElement::DQM_KIND_TH2F:
     case MonitorElement::DQM_KIND_TH2S:
-    case MonitorElement::DQM_KIND_TH2D:
     case MonitorElement::DQM_KIND_TH2I:
+    case MonitorElement::DQM_KIND_TH2D:
     case MonitorElement::DQM_KIND_TH3F:
     case MonitorElement::DQM_KIND_TPROFILE:
     case MonitorElement::DQM_KIND_TPROFILE2D:


### PR DESCRIPTION
Fix following warning attempt:

*** DQMStore: WARNING: cannot extract object '<nHits>CPUvsGPU RecHits per event</nHits>' of type 'TObjString'
*** DQMStore: WARNING: cannot extract object '<recHitsBLay1Charge>CPUvsGPU RecHits Charge Barrel Layer1</recHitsBLay1Charge>' of type 'TObjString'
*** DQMStore: WARNING: cannot extract object '<recHitsBLay1Sizex>CPUvsGPU RecHits SizeX Barrel Layer1</recHitsBLay1Sizex>' of type 'TObjString'
*** DQMStore: WARNING: cannot extract object '<recHitsBLay1Sizey>CPUvsGPU RecHits SizeY Barrel Layer1</recHitsBLay1Sizey>' of type 'TObjString'
*** DQMStore: WARNING: cannot extract object '<recHitsBLay2Charge>CPUvsGPU RecHits Charge Barrel Layer2</recHitsBLay2Charge>' of type 'TObjString'
*** DQMStore: WARNING: cannot extract object '<recHitsBLay2Sizex>CPUvsGPU RecHits SizeX Barrel Layer2</recHitsBLay2Sizex>' of type 'TObjString'
*** DQMStore: WARNING: cannot extract object '<recHitsBLay2Sizey>CPUvsGPU RecHits SizeY Barrel Layer2</recHitsBLay2Sizey>' of type 'TObjString'
*** DQMStore: WARNING: cannot extract object '<recHitsBLay3Charge>CPUvsGPU RecHits Charge Barrel Layer3</recHitsBLay3Charge>' of type 'TObjString'
*** DQMStore: WARNING: cannot extract object '<recHitsBLay3Sizex>CPUvsGPU RecHits SizeX Barrel Layer3</recHitsBLay3Sizex>' of type 'TObjString'
*** DQMStore: WARNING: cannot extract object '<recHitsBLay3Sizey>CPUvsGPU RecHits SizeY Barrel Layer3</recHitsBLay3Sizey>' of type 'TObjString'
*** DQMStore: WARNING: cannot extract object '<recHitsBLay4Charge>CPUvsGPU RecHits Charge Barrel Layer4</recHitsBLay4Charge>' of type 'TObjString'
*** DQMStore: WARNING: cannot extract object '<recHitsBLay4Sizex>CPUvsGPU RecHits SizeX Barrel Layer4</recHitsBLay4Sizex>' of type 'TObjString'
*** DQMStore: WARNING: cannot extract object '<recHitsBLay4Sizey>CPUvsGPU RecHits SizeY Barrel Layer4</recHitsBLay4Sizey>' of type 'TObjString'