### PR TITLE
DQM monitor element of Th2poly

### DIFF
--- a/src/cpp/DQM/DQMNet.cc
+++ b/src/cpp/DQM/DQMNet.cc
@@ -329,6 +329,10 @@ DQMNet::reinstateObject(DQMStore *store, Object &o)
     obj = store->book2DD(name, dynamic_cast<TH2D *>(o.object));
     break;
 
+  case DQM_PROP_TYPE_TH2Poly:
+    obj = store->book2DPoly(name, dynamic_cast<TH2Poly *>(o.object));
+    break;
+
   case DQM_PROP_TYPE_TH3F:
     obj = store->book3D(name, dynamic_cast<TH3F *>(o.object));
     break;

--- a/src/cpp/DQM/DQMNet.h
+++ b/src/cpp/DQM/DQMNet.h
@@ -36,6 +36,7 @@ public:
   static const uint32_t DQM_PROP_TYPE_TH2S = 0x00000021;
   static const uint32_t DQM_PROP_TYPE_TH2D = 0x00000022;
   static const uint32_t DQM_PROP_TYPE_TH2I = 0x00000023;
+  static const uint32_t DQM_PROP_TYPE_TH2Poly = 0x00000024;
   static const uint32_t DQM_PROP_TYPE_TH3F = 0x00000030;
   static const uint32_t DQM_PROP_TYPE_TH3S	 = 0x00000031;
   static const uint32_t DQM_PROP_TYPE_TH3D	 = 0x00000032;

--- a/src/cpp/DQM/DQMStore.cc
+++ b/src/cpp/DQM/DQMStore.cc
@@ -1111,6 +1111,12 @@ DQMStore::book2D(const std::string &dir, const std::string &name, TH2F *h)
   return book(dir, name, "book2D", MonitorElement::DQM_KIND_TH2F, h, collate2D);
 }
 
+MonitorElement *
+DQMStore::book2DPoly(const std::string &dir, const std::string &name, TH2Poly *h)
+{
+  return book(dir, name, "book2DPoly", MonitorElement::DQM_KIND_TH2Poly, h, collate2DPoly);
+}
+
 /// Book 2D histogram based on TH2S.
 MonitorElement * DQMStore::book2S(const std::string &dir, const std::string &name, TH2S *h) {
   return book(dir, name, "book2S", MonitorElement::DQM_KIND_TH2S, h, collate2S);
@@ -1147,6 +1153,17 @@ DQMStore::book2D(const std::string &name, const std::string &title,
   return book2D(pwd_, name, new TH2F(name.c_str(), title.c_str(),
                                      nchX, lowX, highX,
                                      nchY, lowY, highY));
+}
+
+/// Book TH2Poly histogram.
+MonitorElement *
+DQMStore::book2DPoly(const char *name, const char *title,
+                     double lowX, double highX,
+                     double lowY, double highY)
+{
+  return book2DPoly(pwd_, name, new TH2Poly(name, title,
+                                            lowX, highX,
+                                            lowY, highY));
 }
 
 /// Book 2S histogram.
@@ -1591,6 +1608,21 @@ DQMStore::collate2D(MonitorElement *me, TH2F *h, unsigned verbose)
 {
   if (checkBinningMatches(me,h,verbose))
     me->getTH2F()->Add(h);
+}
+
+void
+DQMStore::collate2DPoly(MonitorElement *me, TH2Poly *h, unsigned verbose)
+{
+    if (checkBinningMatches(me,h,verbose)) {
+    TH2Poly *p = me->getTH2Poly();
+    int nbins = p->GetNcells() - 9;
+    for(int ibin=1; ibin<nbins+1; ++ibin) {
+        double value1 = p->GetBinContent(ibin);
+        double value2 = h->GetBinContent(ibin);
+        double total = value1 + value2;
+        p->SetBinContent(ibin, total);
+    }
+  }
 }
 
 void
@@ -2252,6 +2284,17 @@ DQMStore::extract(TObject *obj, const std::string &dir,
       me->copyFrom(h);
     else if (isCollateME(me) || collateHistograms)
       collate2DD(me, h, verbose_);
+    refcheck = me;
+  }
+  else if (TH2Poly *h = dynamic_cast<TH2Poly *>(obj))
+  {
+    MonitorElement *me = findObject(dir, h->GetName());
+    if (! me)
+      me = book2DPoly(dir, h->GetName(), (TH2Poly *) h->Clone());
+    else if (overwrite)
+      me->copyFrom(h);
+    else if (isCollateME(me) || collateHistograms)
+      collate2DPoly(me, h, verbose_);
     refcheck = me;
   }
   else if (TH3F *h = dynamic_cast<TH3F *>(obj))
@@ -3523,6 +3566,11 @@ DQMStore::scaleElements(void)
       case MonitorElement::DQM_KIND_TH2D:
         {
           me.getTH2D()->Scale(factor);
+          break;
+        }
+      case MonitorElement::DQM_KIND_TH2Poly:
+        {
+          me.getTH2Poly()->Scale(factor);
           break;
         }
       case MonitorElement::DQM_KIND_TH3F:

--- a/src/cpp/DQM/DQMStore.cc
+++ b/src/cpp/DQM/DQMStore.cc
@@ -1613,16 +1613,8 @@ DQMStore::collate2D(MonitorElement *me, TH2F *h, unsigned verbose)
 void
 DQMStore::collate2DPoly(MonitorElement *me, TH2Poly *h, unsigned verbose)
 {
-    if (checkBinningMatches(me,h,verbose)) {
-    TH2Poly *p = me->getTH2Poly();
-    int nbins = p->GetNcells() - 9;
-    for(int ibin=1; ibin<nbins+1; ++ibin) {
-        double value1 = p->GetBinContent(ibin);
-        double value2 = h->GetBinContent(ibin);
-        double total = value1 + value2;
-        p->SetBinContent(ibin, total);
-    }
-  }
+  if (checkBinningMatches(me,h,verbose))
+    me->getTH2Poly->Add(h, 1.);
 }
 
 void

--- a/src/cpp/DQM/DQMStore.cc
+++ b/src/cpp/DQM/DQMStore.cc
@@ -1614,7 +1614,7 @@ void
 DQMStore::collate2DPoly(MonitorElement *me, TH2Poly *h, unsigned verbose)
 {
   if (checkBinningMatches(me,h,verbose))
-    me->getTH2Poly->Add(h, 1.);
+    me->getTH2Poly()->Add(h, 1.);
 }
 
 void

--- a/src/cpp/DQM/DQMStore.h
+++ b/src/cpp/DQM/DQMStore.h
@@ -40,10 +40,12 @@ class TH1D;
 class TH2F;
 class TH2S;
 class TH2D;
+class TH2Poly;
 class TH3F;
 class TProfile;
 class TProfile2D;
 class TNamed;
+class TGraph;
 
 
 /** Implements RegEx patterns which occur often in a high-performant
@@ -417,6 +419,11 @@ class DQMStore
   MonitorElement *              book2DD       (const char *name, TH2D *h);
   MonitorElement *              book2DD       (const std::string &name, TH2D *h);
 
+  MonitorElement *              book2DPoly    (const char *name,
+                                               const char *title,
+                                               double lowX, double highX,
+                                               double lowY, double highY);
+
   MonitorElement *              book3D       (const char *name,
                                               const char *title,
                                               int nchX, double lowX, double highX,
@@ -663,6 +670,7 @@ class DQMStore
   MonitorElement *              book2D(const std::string &dir, const std::string &name, TH2F *h);
   MonitorElement *              book2S(const std::string &dir, const std::string &name, TH2S *h);
   MonitorElement *              book2DD(const std::string &dir, const std::string &name, TH2D *h);
+  MonitorElement *              book2DPoly(const std::string &dir, const std::string &name, TH2Poly *h);
   MonitorElement *              book3D(const std::string &dir, const std::string &name, TH3F *h);
   MonitorElement *              bookProfile(const std::string &dir, const std::string &name, TProfile *h);
   MonitorElement *              bookProfile2D(const std::string &folder, const std::string &name, TProfile2D *h);
@@ -677,6 +685,7 @@ class DQMStore
   static void                   collate2D(MonitorElement *me, TH2F *h, unsigned verbose);
   static void                   collate2S(MonitorElement *me, TH2S *h, unsigned verbose);
   static void                   collate2DD(MonitorElement *me, TH2D *h, unsigned verbose);
+  static void                   collate2DPoly(MonitorElement *me, TH2Poly *h, unsigned verbose);
   static void                   collate3D(MonitorElement *me, TH3F *h, unsigned verbose);
   static void                   collateProfile(MonitorElement *me, TProfile *h, unsigned verbose);
   static void                   collateProfile2D(MonitorElement *me, TProfile2D *h, unsigned verbose);

--- a/src/cpp/DQM/MonitorElement.cc
+++ b/src/cpp/DQM/MonitorElement.cc
@@ -47,6 +47,7 @@ MonitorElement::initialise(Kind kind)
   case DQM_KIND_TH2F:
   case DQM_KIND_TH2S:
   case DQM_KIND_TH2D:
+  case DQM_KIND_TH2Poly:
   case DQM_KIND_TH3F:
   case DQM_KIND_TPROFILE:
   case DQM_KIND_TPROFILE2D:
@@ -113,6 +114,12 @@ MonitorElement::initialise(Kind kind, TH1 *rootobj)
   case DQM_KIND_TH2D:
     assert(dynamic_cast<TH2D *>(rootobj));
     assert(! reference_ || dynamic_cast<TH1D *>(reference_));
+    object_ = rootobj;
+    break;
+
+  case DQM_KIND_TH2Poly:
+    assert(dynamic_cast<TH2Poly *>(rootobj));
+    assert(! reference_ || dynamic_cast<TH2Poly *>(reference_));
     object_ = rootobj;
     break;
 
@@ -334,6 +341,7 @@ MonitorElement::Fill(double x, double yw)
     static_cast<TH2S *>(accessRootObject(__PRETTY_FUNCTION__, 2))
       ->Fill(x, yw, 1);
   else if (kind() == DQM_KIND_TH2D) static_cast<TH2D *>(accessRootObject(__PRETTY_FUNCTION__, 2))->Fill(x, yw, 1);
+  else if (kind() == DQM_KIND_TH2Poly) static_cast<TH2Poly *>(accessRootObject(__PRETTY_FUNCTION__, 2))->Fill(x, yw, 1);
   else if (kind() == DQM_KIND_TH2I) static_cast<TH2I *>(accessRootObject(__PRETTY_FUNCTION__, 2))->Fill(x, yw, 1);
   else if (kind() == DQM_KIND_TPROFILE)
     static_cast<TProfile *>(accessRootObject(__PRETTY_FUNCTION__, 1))
@@ -429,6 +437,9 @@ MonitorElement::Fill(double x, double y, double zw)
       ->Fill(x, y, zw);
   else if (kind() == DQM_KIND_TH2D)
     static_cast<TH2D *>(accessRootObject(__PRETTY_FUNCTION__, 2))
+      ->Fill(x, y, zw);
+  else if (kind() == DQM_KIND_TH2Poly)
+    static_cast<TH2Poly *>(accessRootObject(__PRETTY_FUNCTION__, 2))
       ->Fill(x, y, zw);
   else if (kind() == DQM_KIND_TH3F)
     static_cast<TH3F *>(accessRootObject(__PRETTY_FUNCTION__, 2))
@@ -849,6 +860,15 @@ MonitorElement::getTitle(void) const
 
 /*** setter methods (wrapper around ROOT methods) ****/
 //
+// /// set polygonal bin (TH2Poly)
+// void
+// MonitorElement::addBin(TGraph *graph)
+// {
+//   update();
+//   accessRootObject(__PRETTY_FUNCTION__, 2)
+//     ->AddBin(graph);
+// }
+
 /// set content of bin (1-D)
 void
 MonitorElement::setBinContent(int binx, double content)
@@ -1128,6 +1148,27 @@ MonitorElement::softReset(void)
     r->Add(orig);
     orig->Reset();
   }
+  else if (kind() == DQM_KIND_TH2Poly)
+  {
+    TH2Poly *orig = static_cast<TH2Poly *>(object_);
+    TH2Poly *r = static_cast<TH2Poly *>(refvalue_);
+    if (! r)
+    {
+      refvalue_ = r = (TH2Poly*)orig->Clone((std::string(orig->GetName()) + "_ref").c_str());
+      r->SetDirectory(0);
+      r->Reset("");
+    }
+
+    // r->Add(orig);
+    int nbins = r->GetNcells() - 9;
+    for(int ibin=1; ibin<nbins+1; ++ibin) {
+        double value1 = r->GetBinContent(ibin);
+        double value2 = orig->GetBinContent(ibin);
+        double total = value1 + value2;
+        r->SetBinContent(ibin, total);
+    }
+    orig->Reset("");
+  }
   else if (kind() == DQM_KIND_TH3F)
   {
     TH3F *orig = static_cast<TH3F *>(object_);
@@ -1188,6 +1229,7 @@ MonitorElement::disableSoftReset(void)
         || kind() == DQM_KIND_TH2F
         || kind() == DQM_KIND_TH2S
         || kind() == DQM_KIND_TH2D
+        || kind() == DQM_KIND_TH2Poly
         || kind() == DQM_KIND_TH3F)
     {
       TH1 *orig = static_cast<TH1 *>(object_);
@@ -1364,6 +1406,7 @@ MonitorElement::copyFrom(TH1 *from)
         || kind() == DQM_KIND_TH2F
         || kind() == DQM_KIND_TH2S
         || kind() == DQM_KIND_TH2D
+        || kind() == DQM_KIND_TH2Poly
         || kind() == DQM_KIND_TH3F)
       // subtract "reference"
       orig->Add(from, refvalue_, 1, -1);
@@ -1539,6 +1582,14 @@ MonitorElement::getTH2D(void) const
   return static_cast<TH2D *>(accessRootObject(__PRETTY_FUNCTION__, 2));
 }
 
+TH2Poly *
+MonitorElement::getTH2Poly(void) const
+{
+  assert(kind() == DQM_KIND_TH2Poly);
+  const_cast<MonitorElement *>(this)->update();
+  return static_cast<TH2Poly *>(accessRootObject(__PRETTY_FUNCTION__, 2));
+}
+
 TH3F *
 MonitorElement::getTH3F(void) const
 {
@@ -1641,6 +1692,15 @@ MonitorElement::getRefTH2D(void) const
   assert(kind() == DQM_KIND_TH2D);
   const_cast<MonitorElement *>(this)->update();
   return static_cast<TH2D *>
+    (checkRootObject(data_.objname, reference_, __PRETTY_FUNCTION__, 2));
+}
+
+TH2Poly *
+MonitorElement::getRefTH2Poly(void) const
+{
+  assert(kind() == DQM_KIND_TH2Poly);
+  const_cast<MonitorElement *>(this)->update();
+  return static_cast<TH2Poly *>
     (checkRootObject(data_.objname, reference_, __PRETTY_FUNCTION__, 2));
 }
 

--- a/src/cpp/DQM/MonitorElement.h
+++ b/src/cpp/DQM/MonitorElement.h
@@ -12,11 +12,13 @@
 # include "TH2F.h"
 # include "TH2S.h"
 # include "TH2D.h"
+# include "TH2Poly.h"
 # include "TH3F.h"
 # include "TProfile.h"
 # include "TProfile2D.h"
 # include "TObjString.h"
 # include "TAxis.h"
+# include "TGraph.h"
 # include <sys/time.h>
 # include <string>
 # include <set>
@@ -60,6 +62,7 @@ public:
     DQM_KIND_TH2F       = DQMNet::DQM_PROP_TYPE_TH2F,
     DQM_KIND_TH2S       = DQMNet::DQM_PROP_TYPE_TH2S,
     DQM_KIND_TH2D       = DQMNet::DQM_PROP_TYPE_TH2D,
+    DQM_KIND_TH2Poly    = DQMNet::DQM_PROP_TYPE_TH2Poly,
     DQM_KIND_TH3F       = DQMNet::DQM_PROP_TYPE_TH3F,
     DQM_KIND_TH1I       = DQMNet::DQM_PROP_TYPE_TH1I,
     DQM_KIND_TH2I       = DQMNet::DQM_PROP_TYPE_TH2I,
@@ -266,6 +269,7 @@ private:
 public:
   std::string getAxisTitle(int axis = 1) const;
   std::string getTitle(void) const;
+  // void addBin(TGraph *graph);
   void setBinContent(int binx, double content);
   void setBinContent(int binx, int biny, double content);
   void setBinContent(int binx, int biny, int binz, double content);
@@ -349,6 +353,7 @@ public:
   TH2F *getTH2F(void) const;
   TH2S *getTH2S(void) const;
   TH2D *getTH2D(void) const;
+  TH2Poly *getTH2Poly(void) const;
   TH3F *getTH3F(void) const;
   TProfile *getTProfile(void) const;
   TProfile2D *getTProfile2D(void) const;
@@ -363,6 +368,7 @@ public:
   TH2F *getRefTH2F(void) const;
   TH2S *getRefTH2S(void) const;
   TH2D *getRefTH2D(void) const;
+  TH2Poly *getRefTH2Poly(void) const;
   TH3F *getRefTH3F(void) const;
   TProfile *getRefTProfile(void) const;
   TProfile2D *getRefTProfile2D(void) const;

--- a/src/cpp/DQM/QTest.cc
+++ b/src/cpp/DQM/QTest.cc
@@ -99,7 +99,7 @@ float Comp2RefEqualH::runTest(const MonitorElement*me)
     ref_ = me->getRefTH1D(); //access Ref hiso 
     if (nbins != nbinsref) return -1;
   } 
-  //-- TH2
+  //-- TH2F
   else if (me->kind()==MonitorElement::DQM_KIND_TH2F)
   { 
     nbins = me->getTH2F()->GetXaxis()->GetNbins() *
@@ -111,7 +111,7 @@ float Comp2RefEqualH::runTest(const MonitorElement*me)
     if (nbins != nbinsref) return -1;
   } 
 
-  //-- TH2
+  //-- TH2S
   else if (me->kind()==MonitorElement::DQM_KIND_TH2S)
   { 
     nbins = me->getTH2S()->GetXaxis()->GetNbins() *
@@ -123,7 +123,7 @@ float Comp2RefEqualH::runTest(const MonitorElement*me)
     if (nbins != nbinsref) return -1;
   } 
 
-  //-- TH2
+  //-- TH2D
   else if (me->kind()==MonitorElement::DQM_KIND_TH2D)
   { 
     nbins = me->getTH2D()->GetXaxis()->GetNbins() *
@@ -225,6 +225,12 @@ float Comp2RefChi2::runTest(const MonitorElement *me)
   { 
     h = me->getTH2I(); // access Test histo
     ref_ = me->getRefTH2I(); //access Ref histo
+  } 
+  //-- TH2Poly
+  else if (me->kind()==MonitorElement::DQM_KIND_TH2Poly)
+  { 
+    h = me->getTH2Poly(); // access Test histo
+    ref_ = me->getRefTH2Poly(); //access Ref histo
   } 
   //-- TH1D
   else if (me->kind()==MonitorElement::DQM_KIND_TH1D)
@@ -831,14 +837,14 @@ float NoisyChannel::runTest(const MonitorElement *me)
     nbins = me->getTH1D()->GetXaxis()->GetNbins(); 
     h  = me->getTH1D(); // access Test histo
   } 
-  //-- TH2
+  //-- TH2F
   else if (me->kind()==MonitorElement::DQM_KIND_TH2F)
   { 
     nbins = me->getTH2F()->GetXaxis()->GetNbins() *
             me->getTH2F()->GetYaxis()->GetNbins();
     h  = me->getTH2F(); // access Test histo
   } 
-  //-- TH2
+  //-- TH2S
   else if (me->kind()==MonitorElement::DQM_KIND_TH2S)
   { 
     nbins = me->getTH2S()->GetXaxis()->GetNbins() *
@@ -851,7 +857,13 @@ float NoisyChannel::runTest(const MonitorElement *me)
             me->getTH2I()->GetYaxis()->GetNbins();
     h  = me->getTH2I(); // access Test histo
   } 
-  //-- TH2
+  else if (me->kind()==MonitorElement::DQM_KIND_TH2Poly)
+  { 
+    nbins = me->getTH2Poly()->GetXaxis()->GetNbins() *
+            me->getTH2Poly()->GetYaxis()->GetNbins();
+    h  = me->getTH2Poly(); // access Test histo
+  } 
+  //-- TH2D
   else if (me->kind()==MonitorElement::DQM_KIND_TH2D)
   { 
     nbins = me->getTH2D()->GetXaxis()->GetNbins() *

--- a/src/cpp/DQM/QTest.cc
+++ b/src/cpp/DQM/QTest.cc
@@ -135,6 +135,18 @@ float Comp2RefEqualH::runTest(const MonitorElement*me)
     if (nbins != nbinsref) return -1;
   } 
 
+  //-- TH2Poly
+  else if (me->kind()==MonitorElement::DQM_KIND_TH2Poly)
+  {
+    nbins = me->getTH2Poly()->GetXaxis()->GetNbins() *
+            me->getTH2Poly()->GetYaxis()->GetNbins();
+    nbinsref = me->getRefTH2Poly()->GetXaxis()->GetNbins() *
+               me->getRefTH2Poly()->GetYaxis()->GetNbins();
+    h = me->getTH2Poly(); // access Test histo
+    ref_ = me->getRefTH2Poly(); //access Ref hiso
+    if (nbins != nbinsref) return -1;
+  }
+
   //-- TH3
   else if (me->kind()==MonitorElement::DQM_KIND_TH3F)
   { 

--- a/src/cpp/DQM/VisDQMIndex.h
+++ b/src/cpp/DQM/VisDQMIndex.h
@@ -114,7 +114,7 @@ class VisDQMCache;
       monitor element objects stored anywhere in the index.
 
     - Key #MASTER_TSTREAMERINFO, binary data: Serialised ROOT
-      TStreamerInfo objects for TH1F, TH1I, TH1S, TH2F, TH2S, TH2I, TH3F, TH3S,
+      TStreamerInfo objects for TH1F, TH1I, TH1S, TH2F, TH2S, TH2I, TH2Poly, TH3F, TH3S,
       TProfile and TProfile2D types.  The sample's streamer info
       should be used whenever reading in ROOT object data for the
       sample.  All data originating from a particular ROOT version

--- a/src/cpp/DQM/VisDQMIndex.h
+++ b/src/cpp/DQM/VisDQMIndex.h
@@ -200,6 +200,7 @@ public:
   static const uint32_t SUMMARY_PROP_TYPE_TH2S = 0x00000021;
   static const uint32_t SUMMARY_PROP_TYPE_TH2D = 0x00000022;
   static const uint32_t SUMMARY_PROP_TYPE_TH2I = 0x00000023;
+  static const uint32_t SUMMARY_PROP_TYPE_TH2Poly = 0x00000024;
   static const uint32_t SUMMARY_PROP_TYPE_TH3F = 0x00000030;
   static const uint32_t SUMMARY_PROP_TYPE_TH3S = 0x00000031;
   static const uint32_t SUMMARY_PROP_TYPE_TH3D = 0x00000032;

--- a/src/cpp/DQM/VisDQMTools.h
+++ b/src/cpp/DQM/VisDQMTools.h
@@ -255,7 +255,7 @@ buildCompleteStreamerInfo(std::string &data)
       "TH1F", "TH1S", "TH1D", "TH1I",
       "TH2F", "TH2S", "TH2D", "TH2I",
       "TH3F", "TH3S", "TH3D", "TH3I",
-      "TProfile", "TProfile2D", 0
+      "TH2Poly", "TProfile", "TProfile2D", 0
     };
 
   int i = 0;

--- a/src/cpp/DQM/index.cc
+++ b/src/cpp/DQM/index.cc
@@ -2553,6 +2553,7 @@ static int dumpIndex(const Filename &indexdir, DumpType what, size_t sampleid) {
                 << (type == VisDQMIndex::SUMMARY_PROP_TYPE_TH2F ? ", TH2F" : "")
                 << (type == VisDQMIndex::SUMMARY_PROP_TYPE_TH2S ? ", TH2S" : "")
                 << (type == VisDQMIndex::SUMMARY_PROP_TYPE_TH2I ? ", TH2I" : "")
+                << (type == VisDQMIndex::SUMMARY_PROP_TYPE_TH2Poly ? ", TH2Poly" : "")
                 << (type == VisDQMIndex::SUMMARY_PROP_TYPE_TH3F ? ", TH3F" : "")
                 << (type == VisDQMIndex::SUMMARY_PROP_TYPE_TH3S ? ", TH3S" : "")
                 << (type == VisDQMIndex::SUMMARY_PROP_TYPE_TPROF ? ", TPROF"

--- a/src/cpp/DQM/index.cc
+++ b/src/cpp/DQM/index.cc
@@ -475,6 +475,7 @@ static MEClass classifyMonitorElement(DQMStore & /* store */,
   case MonitorElement::DQM_KIND_TH2F:
   case MonitorElement::DQM_KIND_TH2S:
   case MonitorElement::DQM_KIND_TH2D:
+  case MonitorElement::DQM_KIND_TH2Poly:
   case MonitorElement::DQM_KIND_TH2I:
   case MonitorElement::DQM_KIND_TH3F:
   case MonitorElement::DQM_KIND_TPROFILE:
@@ -1033,6 +1034,7 @@ static void extend(VisDQMIndex &ix, VisDQMIndex::Sample &s, uint64_t nsample,
             case MonitorElement::DQM_KIND_TH2F:
             case MonitorElement::DQM_KIND_TH2S:
             case MonitorElement::DQM_KIND_TH2D:
+            case MonitorElement::DQM_KIND_TH2Poly:
             case MonitorElement::DQM_KIND_TH2I:
             case MonitorElement::DQM_KIND_TH3F:
             case MonitorElement::DQM_KIND_TPROFILE:
@@ -1234,6 +1236,7 @@ static void readFileStream(FileInfo &fi, std::string &streamerinfo,
     case MonitorElement::DQM_KIND_TH2S:
     case MonitorElement::DQM_KIND_TH2I:
     case MonitorElement::DQM_KIND_TH2D:
+    case MonitorElement::DQM_KIND_TH2Poly:
     case MonitorElement::DQM_KIND_TH3F:
     case MonitorElement::DQM_KIND_TPROFILE:
     case MonitorElement::DQM_KIND_TPROFILE2D:
@@ -1349,6 +1352,7 @@ static void readFileStreamProtocolBuffer(
     case MonitorElement::DQM_KIND_TH2S:
     case MonitorElement::DQM_KIND_TH2I:
     case MonitorElement::DQM_KIND_TH2D:
+    case MonitorElement::DQM_KIND_TH2Poly:
     case MonitorElement::DQM_KIND_TH3F:
     case MonitorElement::DQM_KIND_TPROFILE:
     case MonitorElement::DQM_KIND_TPROFILE2D:

--- a/src/cpp/DQM/serverext.cc
+++ b/src/cpp/DQM/serverext.cc
@@ -945,6 +945,7 @@ static void objectToJSON(const std::string &name, const std::string &path,
                : type == DQMNet::DQM_PROP_TYPE_TH2S     ? "TH2S"
                : type == DQMNet::DQM_PROP_TYPE_TH2I     ? "TH2I"
                : type == DQMNet::DQM_PROP_TYPE_TH2D     ? "TH2D"
+               : type == DQMNet::DQM_PROP_TYPE_TH2Poly  ? "TH2Poly"
                : type == DQMNet::DQM_PROP_TYPE_TH3F     ? "TH3F"
                : type == DQMNet::DQM_PROP_TYPE_TH3S     ? "TH3S"
                : type == DQMNet::DQM_PROP_TYPE_TH3D     ? "TH3D"

--- a/src/python/Core/GUI.py
+++ b/src/python/Core/GUI.py
@@ -17,7 +17,7 @@ from cherrypy.lib.static import serve_file
 from Cheetah.Template import Template
 from Monitoring.Core.Utils.Common import _logerr, _logwarn, ParameterManager
 from io import StringIO
-from stat import *
+from stat import ST_MTIME, ST_SIZE
 from jsmin import jsmin
 from http import client
 import pickle
@@ -357,7 +357,7 @@ class Server:
 
     def _addCSSFragment(self, filename):
         """Add a piece of CSS to the master HTML page."""
-        if not filename in dict(self.css):
+        if filename not in dict(self.css):
             with open(filename) as _f:
                 text = _f.read()
             if filename.startswith(self._yui):
@@ -401,7 +401,7 @@ class Server:
 
     def _addJSFragment(self, filename, minimise=True):
         """Add a piece of javascript to the master HTML page."""
-        if not filename in dict(self.js):
+        if filename not in dict(self.js):
             with open(filename) as _f:
                 text = _f.read()
             if minimise:
@@ -745,10 +745,7 @@ class Server:
         )
         summary = ""
 
-        def cmp(a, b):
-            return (a > b) - (a < b)
-
-        self.checksums.sort(lambda a, b: cmp(a["srcfile"], b["srcfile"]))
+        self.checksums.sort(key=lambda x: x["srcfile"])
         for i in self.checksums:
             summary += fmt % i
 

--- a/src/python/Core/GUI.py
+++ b/src/python/Core/GUI.py
@@ -652,8 +652,8 @@ class Server:
                 severity=logging.WARNING,
             )
 
-        self._noResponseCaching()
-        return str(e)
+            self._noResponseCaching()
+            return str(e)
 
     # -----------------------------------------------------------------
     @expose
@@ -693,8 +693,8 @@ class Server:
                 severity=logging.WARNING,
             )
 
-        self._noResponseCaching()
-        return str(e)
+            self._noResponseCaching()
+            return str(e)
 
     # -----------------------------------------------------------------
     @expose
@@ -709,7 +709,7 @@ class Server:
                 for s in self.sources:
                     if getattr(s, "plothook", None) == args[0]:
                         (type, data) = s.plot(*args[1:], **kwargs)
-                        if type != None:
+                        if type is not None:
                             self._noResponseCaching()
                             response.headers["Content-Length"] = str(len(data))
                             response.headers["Content-Type"] = type


### PR DESCRIPTION
This PR introduces a new type of DQM MonitorElement, TH2Poly, for HGCal DQM in the future. This feature allows the display of polygonal histograms on the CMS DQM GUI. As a demonstration, a wafer map can be displayed like the screenshot here [1].

TH2Poly is a 2D histogram class inherited from TH2. Polygonal bins, defined by TGraph, can be loaded using the AddBin() method. After setting up the polygonal bins, a TH2Poly object can store information through Fill() or SetBinContent().

A workflow for creating polygonal histograms looks like this:
DQM Service -> DQM EDAnalyzer -> CMS DQM GUI

An implementation of TH2Poly in DQM Service and MonitorElement is necessary to display the polygonal histograms. It involves updates on two repositories: dqmgui_prod and cmssw. The idea is implemented in a user branch of cmssw [2]. From the branch, monitor elements of the TH2Poly object can be stored in a DQM root file [3]. We will prepare another pull request to cmssw soon.

A related issue to this PR can be found here, https://github.com/cms-DQM/dqmgui_prod/issues/13

@pfs, @hqucms

[1] https://ykao.web.cern.ch/ykao/raw_data_handling/hgcal_dqm_gui/screenshot_demo_th2poly_wafermap.png
[2] https://github.com/ywkao/cmssw/commit/d9e70fcfc5ef5b783699df414c12509e1bc89a89
[3] A DQM root file: /afs/cern.ch/work/y/ykao/public/example_HGCAL_DQM/DQM_V0001_HGCAL_R000123469.root