### PR TITLE
add code so that priority is given to 2023 runs

### DIFF
--- a/bin/visDQMImportDaemon
+++ b/bin/visDQMImportDaemon
@@ -71,7 +71,9 @@ def logme(msg, *args):
 # Order input files so we process them in a sane order:
 # - process .pb.dmqinfo files first
 # - process .dat.dmqinfo files next
-# - descending by run
+# - compare class (online first)
+# - priority given to 2023 collision runs first
+# - ascending by run
 # - ascending by version
 # - descending by dataset
 def orderFiles(a, b):
@@ -99,6 +101,21 @@ def orderFiles(a, b):
   if diff: return diff
   diff = classOrder.index(a['class']) - classOrder.index(b['class'])
   if diff: return diff
+####################################################################
+## Priority given to 2023 Collision runs first 
+## So that Rereco data of 2022 will be indexed later
+## This hard-wired code must be updated when we move to 2024
+####################################################################
+  if a['runnr'] >= 365753:
+    if b['runnr'] >= 365753:
+      diff = 0
+    else:
+      diff = -1
+  else:
+    if b['runnr'] >= 365753:
+      diff = 1
+  if diff: return diff
+####################################################################
   diff = a['runnr'] - b['runnr']
   if diff: return diff
   diff = a['version'] - b['version']


### PR DESCRIPTION
This pull request includes a block of code that performs file indexing for 2023 collision runs first (before the priority is given to smaller run numbers). 
i.e. we will check the run number and see if is greater than 365753. If yes, perform file indexing first. If not, most likely this is ReReco dataset and perform the indexing later.


