### PR TITLE
Further Fixes for python3

### DIFF
--- a/bin/visDQMExportDaemon
+++ b/bin/visDQMExportDaemon
@@ -163,7 +163,7 @@ class Exporter(Thread):
                 finfo = "%s/%s.dqminfo" % (EXPORTDIR, self._sample.streamFile)
                 try:
                     (fd, tmp) = mkstemp(dir=EXPORTDIR)
-                    os.write(fd, str(self._sample.toInfo()))
+                    os.write(fd, str(self._sample.toInfo()).encode())
                     os.close(fd)
                     os.rename(tmp, finfo)
                     for n in NEXT:

--- a/bin/visDQMMergeDaemon
+++ b/bin/visDQMMergeDaemon
@@ -143,7 +143,7 @@ while True:
                 finfo["mergedto"] = info["info"]["path"]
                 (dname, filepart) = fname.rsplit("/", 1)
                 (fd, tmp) = mkstemp(dir=dname)
-                os.write(fd, "%s\n" % finfo)
+                os.write(fd, f"{finfo}\n".encode())
                 os.close(fd)
                 os.chmod(tmp, 0o666 & ~myumask)
                 os.remove("%s.dqminfo" % fname)
@@ -154,7 +154,7 @@ while True:
             info["mergedfrom"] = info["files"]
             (dname, filepart) = path.rsplit("/", 1)
             (fd, tmp) = mkstemp(dir=dname)
-            os.write(fd, "%s\n" % info["info"])
+            os.write(fd, f"{info['info']}\n".encode())
             os.close(fd)
             os.chmod(tmp, 0o666 & ~myumask)
             os.rename(tmp, minfo)

--- a/bin/visDQMZipCastorStager
+++ b/bin/visDQMZipCastorStager
@@ -280,7 +280,7 @@ try:
             zinfopath = "%s/%s.zinfo" % (ZIPREPO, info["zpath"])
             (dname, filepart) = zinfopath.rsplit("/", 1)
             (fd, tmp) = mkstemp(dir=dname)
-            os.write(fd, "%s\n" % info)
+            os.write(fd, f"{info}\n".encode())
             os.close(fd)
             os.chmod(tmp, 0o666 & ~myumask)
             os.rename(tmp, zinfopath)

--- a/bin/visDQMZipCastorVerifier
+++ b/bin/visDQMZipCastorVerifier
@@ -219,7 +219,7 @@ try:
             zinfopath = "%s/%s.zinfo" % (ZIPREPO, info["zpath"])
             (dname, filepart) = zinfopath.rsplit("/", 1)
             (fd, tmp) = mkstemp(dir=dname)
-            os.write(fd, "%s\n" % info)
+            os.write(fd, f"{info}\n".encode())
             os.close(fd)
             os.chmod(tmp, 0o666 & ~myumask)
             os.rename(tmp, zinfopath)

--- a/bin/visDQMZipDaemon
+++ b/bin/visDQMZipDaemon
@@ -6,6 +6,7 @@ from Monitoring.Core.Utils.Common import logme
 from tempfile import mkstemp
 from glob import glob
 from stat import *
+from functools import cmp_to_key
 
 
 DROPBOX = sys.argv[1]  # Directory where we receive input ("drop box").
@@ -72,7 +73,7 @@ while True:
         # pattern decided by the receiver. Also keep track of how many
         # times the container has been processed by this agent.
         zips = {}
-        for info in sorted(new, orderFiles):
+        for info in sorted(new, key=cmp_to_key(orderFiles)):
             fname = "%s/%s" % (FILEREPO, info["path"])
             finfo = "%s.dqminfo" % fname
             fsize = os.lstat(fname)[ST_SIZE]
@@ -149,7 +150,7 @@ while True:
                 (dname, filepart) = fname.rsplit("/", 1)
                 (fd, tmp) = mkstemp(dir=dname)
                 del dqminfo["infofile"]
-                os.write(fd, "%s\n" % dqminfo)
+                os.write(fd, f"{dqminfo}\n".encode())
                 os.close(fd)
                 os.chmod(tmp, 0o666 & ~myumask)
                 os.remove(finfo)
@@ -163,7 +164,7 @@ while True:
             zfinfo = info["zinfofile"]
             (dname, filepart) = zippath.rsplit("/", 1)
             (fd, tmp) = mkstemp(dir=dname)
-            os.write(fd, "%s\n" % info["zinfo"])
+            os.write(fd, f'{info["zinfo"]}\n'.encode())
             os.close(fd)
             os.chmod(tmp, 0o666 & ~myumask)
             if os.path.exists(zfinfo):

--- a/bin/visDQMZipFreezeDaemon
+++ b/bin/visDQMZipFreezeDaemon
@@ -87,7 +87,7 @@ while True:
             zinfopath = "%s/%s.zinfo" % (ZIPREPO, info["zpath"])
             (dname, filepart) = zinfopath.rsplit("/", 1)
             (fd, tmp) = mkstemp(dir=dname)
-            os.write(fd, "%s\n" % info)
+            os.write(fd, f"{info}\n".encode())
             os.close(fd)
             os.chmod(tmp, 0o666 & ~myumask)
             os.rename(tmp, zinfopath)


### PR DESCRIPTION
Namely the `os.write` calls' arguments have been adapted to be bytes instead of strings