### PR TITLE
Permanently increase index tree sizes

### DIFF
--- a/src/cpp/DQM/VisDQMIndex.h
+++ b/src/cpp/DQM/VisDQMIndex.h
@@ -10,8 +10,8 @@
 // Define the sizes to be used for the StringAtomTrees
 
 #define OBJECTNAMES 5000000
-#define PATHNAMES 1000000
-#define DATASETNAMES 100000
+#define PATHNAMES 1500000
+#define DATASETNAMES 200000
 #define CMSSWNAMES 10000
 #define STREAMERS 100
 


### PR DESCRIPTION
Now that the deployment procedure has moved permanently to the dqmgui_prod_deployment script, we can permanently increase the DQMGUI's index limits, until at least the end of Run3.