### PR TITLE
Reduce urlshortener's timeout

### DIFF
--- a/src/python/Core/GUI.py
+++ b/src/python/Core/GUI.py
@@ -830,7 +830,7 @@ class Server:
             # so do it seperately.
             # See: https://stackoverflow.com/a/28674109/6562491
 
-            connection = client.HTTPSConnection(host="tinyurl.com", port=443, timeout=3)
+            connection = client.HTTPSConnection(host="tinyurl.com", port=443, timeout=0.7)
             connection.request("GET", f"/api-create.php?url={longUrl}")
             response = connection.getresponse()
 


### PR DESCRIPTION
The Link-me button is annoying slow on P5 deployments. This should make it a bit more tolerable.

Tested with:

```bash
source /data/srv/current/apps/dqmgui/128/etc/profile.d/env.sh 
python
```
And then:
```python
from http import client

connection = client.HTTPSConnection(host="tinyurl.com", port=443, timeout=0.7)
connection.request("GET", "/api-create.php?url=www.test.com")
```

On both `dqm/dev` and `dqm/online-playback`