### PR TITLE
Replace tinyurl with CERN's URL shortener

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,5 @@ matplotlib
 pillow
 jsmin
 Cheetah3
+cernrequests
 . # Also install dqmgui itself

--- a/src/python/Core/GUI.py
+++ b/src/python/Core/GUI.py
@@ -6,6 +6,18 @@
 # such as file and socket operations.  On "straight" python code the
 # interpreter yields the lock only every N byte code instructions;
 # this server configures a large N (1'000'000).
+import pickle
+import sys
+import os
+import os.path
+import re
+import tempfile
+import time
+import inspect
+import logging
+import traceback
+import hashlib
+import base64
 from importlib import import_module
 from imp import get_suffixes
 from copy import deepcopy
@@ -15,14 +27,12 @@ from threading import Thread, Lock
 from cherrypy import expose, HTTPError, request, response, engine, log, tools
 from cherrypy.lib.static import serve_file
 from Cheetah.Template import Template
-from Monitoring.Core.Utils.Common import _logerr, _logwarn, ParameterManager
 from io import StringIO
 from stat import ST_MTIME, ST_SIZE
-from jsmin import jsmin
 from http import client
-import pickle
-import sys, os, os.path, re, tempfile, time, inspect, logging, traceback, hashlib
-import base64
+from jsmin import jsmin
+from Monitoring.Core.Utils.Common import _logerr, _logwarn, ParameterManager
+
 
 _SESSION_REDIRECT = (
     "<html><head><script>location.replace('%s')</script></head>"
@@ -830,7 +840,7 @@ class Server:
             # so do it seperately.
             # See: https://stackoverflow.com/a/28674109/6562491
 
-            connection = client.HTTPSConnection(host="tinyurl.com", port=443, timeout=0.7)
+            connection = client.HTTPSConnection(host="web-redirector-v2-qa.web.cern.ch", port=443, timeout=0.7)
             connection.request("GET", f"/api-create.php?url={longUrl}")
             response = connection.getresponse()
 

--- a/src/python/Core/GUI.py
+++ b/src/python/Core/GUI.py
@@ -19,7 +19,6 @@ import traceback
 import hashlib
 import base64
 import json
-from typing import Union
 from importlib import import_module
 from imp import get_suffixes
 from copy import deepcopy
@@ -33,9 +32,14 @@ from io import StringIO
 from stat import ST_MTIME, ST_SIZE
 from http import client
 from jsmin import jsmin
-import cernrequests
 from dotenv import load_dotenv
-from Monitoring.Core.Utils.Common import _logerr, _logwarn, ParameterManager
+from Monitoring.Core.Utils.Common import (
+    _logerr,
+    _logwarn,
+    ParameterManager,
+    parse_http_proxy_config,
+)
+from Monitoring.Core.Utils.Auth import get_cern_sso_api_token
 
 
 _SESSION_REDIRECT = (
@@ -43,9 +47,6 @@ _SESSION_REDIRECT = (
     + "<body><noscript>Please enable JavaScript to use this"
     + " service</noscript></body></html>"
 )
-
-# Load dotenv from the cwd, which should be <state dir>/dqmgui
-load_dotenv(os.path.join(os.getcwd(), ".env"))
 
 
 def extension(modules, what, *args):
@@ -223,9 +224,8 @@ class Server:
        Server integrity check of source files."""
 
     def __init__(self, cfgfile, cfg, modules):
-        # Don't use a map, because we want to iterate over
-        # the modules many times
-        # modules = map(import_module, modules)
+        # Load dotenv from the cwd, which should be <state dir>/dqmgui
+        load_dotenv(os.path.join(os.getcwd(), ".env"))
         self.instrument = cfg.instrument
         self.checksums = []
         self.stamp = time.time()
@@ -235,6 +235,16 @@ class Server:
         self.templates = {}
         self.css = []
         self.js = []
+        # Get the client id and client secret from the environment.
+        # Those are required to get an access token and authenticate
+        # against the shortener service.
+        # If they're not provided, they will be set to None,
+        # shortening will not work, and the long URLs will be returned instead.
+        self.client_id = os.environ.get("CERN_SSO_CLIENT_ID")
+        self.client_secret = os.environ.get("CERN_SSO_CLIENT_SECRET")
+        self.proxy_url, self.proxy_port = parse_http_proxy_config(
+            os.environ.get("http_proxy")
+        )
 
         monitor_root = os.getenv("MONITOR_ROOT")
         if os.access("%s/xdata/templates/index.tmpl" % monitor_root, os.R_OK):
@@ -851,23 +861,29 @@ class Server:
         shortUrl = longUrl
 
         try:
-            # Get the client id and client secret from the envirnoment.
-            # Those are required to get an access token and authenticate
-            # against the shortener service.
-            client_id = os.environ.get("CERN_SSO_CLIENT_ID")
-            client_secret = os.environ.get("CERN_SSO_CLIENT_SECRET")
-            sso_token = self._get_cern_sso_api_token(
-                client_id=client_id,
-                client_secret=client_secret,
+            sso_token = get_cern_sso_api_token(
+                client_id=self.client_id,
+                client_secret=self.client_secret,
                 target_application=TARGET_APPLICATION,
             )
             assert sso_token
 
-            # Add a timeout to the request to URL shortener service
-            # See: https://stackoverflow.com/a/28674109/6562491
-            connection = client.HTTPSConnection(
-                host=SHORTENER_SERVICE_BASE_URL, port=443, timeout=0.7
-            )
+            # We're using http.client to add a timeout to the request
+            # to the URL shortener service, which is why we're not using
+            # the requests module.
+            # See also: https://stackoverflow.com/a/28674109/6562491
+            # If http_proxy is set in the environment, use it to
+            # access the URL shortener service.
+            if self.proxy_url and self.proxy_port:
+                connection = client.HTTPSConnection(
+                    host=self.proxy_url, port=self.proxy_port, timeout=0.7
+                )
+                connection.set_tunnel(host=SHORTENER_SERVICE_BASE_URL, port=443)
+            else:
+                connection = client.HTTPSConnection(
+                    host=SHORTENER_SERVICE_BASE_URL, port=443, timeout=0.7
+                )
+
             connection.request(
                 "POST",
                 "/_/api/shorturlentry",
@@ -904,24 +920,6 @@ class Server:
             log(f"WARNING: unable to shorten URL: {longUrl}. Reason: {repr(e)}")
 
         return f'{{"id": "{shortUrl}"}}'
-
-    @staticmethod
-    def _get_cern_sso_api_token(
-        client_id: Union[str, None],
-        client_secret: Union[str, None],
-        target_application: Union[str, None],
-    ) -> Union[str, None]:
-        sso_token = None
-        if not client_id or not client_secret:
-            raise Exception(
-                "client_id and client_secret are both required to get an SSO token"
-            )
-        sso_token, sso_token_expiration = cernrequests.get_api_token(
-            client_id=client_id,
-            client_secret=client_secret,
-            target_application=target_application,
-        )
-        return sso_token
 
     def sessionIndex(self, session, *args, **kwargs):
         """Generate top level session index.  This produces the main GUI web

--- a/src/python/Core/GUI.py
+++ b/src/python/Core/GUI.py
@@ -18,6 +18,8 @@ import logging
 import traceback
 import hashlib
 import base64
+import json
+from typing import Union
 from importlib import import_module
 from imp import get_suffixes
 from copy import deepcopy
@@ -31,6 +33,8 @@ from io import StringIO
 from stat import ST_MTIME, ST_SIZE
 from http import client
 from jsmin import jsmin
+import cernrequests
+from dotenv import load_dotenv
 from Monitoring.Core.Utils.Common import _logerr, _logwarn, ParameterManager
 
 
@@ -39,6 +43,9 @@ _SESSION_REDIRECT = (
     + "<body><noscript>Please enable JavaScript to use this"
     + " service</noscript></body></html>"
 )
+
+# Load dotenv from the cwd, which should be <state dir>/dqmgui
+load_dotenv(os.path.join(os.getcwd(), ".env"))
 
 
 def extension(modules, what, *args):
@@ -827,6 +834,16 @@ class Server:
     @expose
     @tools.params()
     def urlshortener(self, *args, **kwargs):
+        # https://gitlab.cern.ch/webservices/web-redirector-v2/-/tree/master/app/api?ref_type=heads
+
+        # QA url shortener endpoint
+        # SHORTENER_SERVICE_BASE_URL = "web-redirector-v2-qa.web.cern.ch"
+        # TARGET_APPLICATION = "web-redirector-v2-qa"
+
+        # Production url shortener endpoint
+        SHORTENER_SERVICE_BASE_URL = "web-redirector-v2-production-cern-ch.web.cern.ch"
+        TARGET_APPLICATION = "web-redirector-v2-production-cern-ch"
+
         if not "url" in kwargs.keys():
             return "{}"
 
@@ -834,29 +851,77 @@ class Server:
         shortUrl = longUrl
 
         try:
-            # Add a timeout to the request to tinyurl, as it takes ages to fail
-            # in case we don't have acess to the outside world (see: P5).
-            # Timeout is ignored in the part of URL to IP resolution,
-            # so do it seperately.
+            # Get the client id and client secret from the envirnoment.
+            # Those are required to get an access token and authenticate
+            # against the shortener service.
+            client_id = os.environ.get("CERN_SSO_CLIENT_ID")
+            client_secret = os.environ.get("CERN_SSO_CLIENT_SECRET")
+            sso_token = self._get_cern_sso_api_token(
+                client_id=client_id,
+                client_secret=client_secret,
+                target_application=TARGET_APPLICATION,
+            )
+            assert sso_token
+
+            # Add a timeout to the request to URL shortener service
             # See: https://stackoverflow.com/a/28674109/6562491
-
-            connection = client.HTTPSConnection(host="web-redirector-v2-qa.web.cern.ch", port=443, timeout=0.7)
-            connection.request("GET", f"/api-create.php?url={longUrl}")
+            connection = client.HTTPSConnection(
+                host=SHORTENER_SERVICE_BASE_URL, port=443, timeout=0.7
+            )
+            connection.request(
+                "POST",
+                "/_/api/shorturlentry",
+                headers={
+                    "Authorization": "Bearer " + sso_token,
+                    "Content-Type": "application/json",
+                    "Accept": "application/json",
+                },
+                body=json.dumps(
+                    {"targetUrl": longUrl, "description": "", "appendQuery": False}
+                ),
+            )
             response = connection.getresponse()
-
-            if response.status == 200:
-                shortUrl = response.read().decode("utf-8")
+            if response.status == 200 or response.status == 201:  # OK or Created
+                response_payload = response.read().decode("utf-8")
+                try:
+                    shortUrl = f"https://cern.ch/{json.loads(response_payload)['slug']}"
+                except json.decoder.JSONDecodeError:
+                    log(
+                        f"WARNING: unable to shorten URL: {longUrl}. Reason: invalid response received from url shortener"
+                    )
+                except KeyError:
+                    log(
+                        f"WARNING: unable to shorten URL: {longUrl}. Reason: No 'slug' found in response"
+                    )
             else:
                 log(
                     f"WARNING: urlshortener returned status: {response.status} and response: {response.read().decode()} for url: {longUrl}",
                     severity=logging.WARNING,
                 )
-
             connection.close()
+
         except Exception as e:
             log(f"WARNING: unable to shorten URL: {longUrl}. Reason: {repr(e)}")
 
-        return '{"id": "%s"}' % shortUrl
+        return f'{{"id": "{shortUrl}"}}'
+
+    @staticmethod
+    def _get_cern_sso_api_token(
+        client_id: Union[str, None],
+        client_secret: Union[str, None],
+        target_application: Union[str, None],
+    ) -> Union[str, None]:
+        sso_token = None
+        if not client_id or not client_secret:
+            raise Exception(
+                "client_id and client_secret are both required to get an SSO token"
+            )
+        sso_token, sso_token_expiration = cernrequests.get_api_token(
+            client_id=client_id,
+            client_secret=client_secret,
+            target_application=target_application,
+        )
+        return sso_token
 
     def sessionIndex(self, session, *args, **kwargs):
         """Generate top level session index.  This produces the main GUI web

--- a/src/python/Core/Utils/Auth.py
+++ b/src/python/Core/Utils/Auth.py
@@ -1,0 +1,35 @@
+from typing import Union
+from datetime import datetime, timedelta
+import cernrequests
+
+sso_token = None
+sso_token_expiration = None
+# How much time before the token expiration should
+# we request a new one.
+EXPIRATION_DEADLINE = timedelta(minutes=5)
+
+
+def is_sso_token_still_valid(sso_token_expiration: Union[datetime, None]):
+    if not sso_token_expiration:
+        return False
+    return (sso_token_expiration - datetime.now()) > EXPIRATION_DEADLINE
+
+
+def get_cern_sso_api_token(
+    client_id: Union[str, None],
+    client_secret: Union[str, None],
+    target_application: Union[str, None],
+) -> Union[str, None]:
+    global sso_token
+    global sso_token_expiration
+    if not client_id or not client_secret:
+        raise Exception(
+            "client_id and client_secret are both required to get an SSO token"
+        )
+    if not is_sso_token_still_valid(sso_token_expiration):
+        sso_token, sso_token_expiration = cernrequests.get_api_token(
+            client_id=client_id,
+            client_secret=client_secret,
+            target_application=target_application,
+        )
+    return sso_token

--- a/src/python/Core/Utils/Common.py
+++ b/src/python/Core/Utils/Common.py
@@ -1,8 +1,13 @@
-import os, re, time, calendar, logging, sys
+import os
+import re
+import time
+import calendar
+import logging
+import sys
+import inspect
 from cherrypy import log, Tool, request
 from cherrypy._cpreqbody import Part
 from datetime import datetime
-import inspect
 
 RE_DIGIT_SEQ = re.compile(r"([-+]?\d+)")
 RE_THOUSANDS = re.compile(r"(\d)(\d{3}($|\D))")

--- a/src/python/Core/Utils/Common.py
+++ b/src/python/Core/Utils/Common.py
@@ -5,6 +5,8 @@ import calendar
 import logging
 import sys
 import inspect
+from typing import Tuple, Union
+from urllib.parse import urlparse
 from cherrypy import log, Tool, request
 from cherrypy._cpreqbody import Part
 from datetime import datetime
@@ -170,6 +172,27 @@ def sizevalue(val):
         return float(m.group(1)) * scale[m.group(2)]
     else:
         return float(val)
+
+
+# Parse the http_proxy env variable,
+# to be used to access http cern.ch resources
+# from P5
+def parse_http_proxy_config(
+    proxy_url_to_parse: str,
+) -> Tuple[Union[str, None], Union[int, None]]:
+    if not proxy_url_to_parse:
+        return None, None
+    parsed_proxy_url = urlparse(proxy_url_to_parse)
+
+    proxy_url = parsed_proxy_url.hostname
+    proxy_port = parsed_proxy_url.port
+
+    if not proxy_port:
+        if parsed_proxy_url.scheme == "https":
+            proxy_port = 443
+        else:
+            proxy_port = 80
+    return proxy_url, proxy_port
 
 
 class ParameterManager(Tool):


### PR DESCRIPTION
As mentioned in #43, tinyurl will stop providing the free url shortener API. This PR replaces it with the internal CERN one: https://gitlab.cern.ch/webservices/web-redirector-v2/-/tree/master/app/api?ref_type=heads

- For this to work, an `.env` file with two variables (`CERN_SSO_CLIENT_ID`, `CERN_SSO_CLIENT_SECRET`) must be provided by the user during the deployment procedure (see what changes [here](https://github.com/cms-DQM/dqmgui_prod_deployment/wiki/Deployment-at-Point-5#4-start-the-installation)). An example can be seen below:
  ```bash
  CERN_SSO_CLIENT_ID=<id>
  CERN_SSO_CLIENT_SECRET=<secret>
  ```
  Both can be acquired by creating an application registration (see [here](https://github.com/cms-DQM/dqmgui_prod_deployment/wiki/Creating-an-application-registration) for instructions). This is required to acquire an SSO token for the application. 
- sso tokens will be re-used, until 5 minutes before they expire.
- If `http_proxy` is set in the environment the DQMGUI is running in, it will be honored and the GUI will try to use it to access the URL shortener service. This is especially important for P5 deployments. More on `http_proxy`:
  - https://everything.curl.dev/usingcurl/proxies/env.html
  - https://www.ibm.com/docs/en/ste/11.0.0?topic=node-proxy-configuration-using-environment-variables
  There is no consensus on whether it should be lowercase or uppercase.




Resolves #43 