### PR TITLE
Update JSROOT to v6

### DIFF
--- a/src/templates/index-comp.tmpl
+++ b/src/templates/index-comp.tmpl
@@ -4,7 +4,7 @@
  <head
   ><meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1"
   /><meta name="keywords" content="CMS, DQM, data quality monitoring, histogram display"
-  /><script type="text/javascript" src="$ROOTPATH/jsroot/scripts/JSRootCore.js"></script>
+  /><script type="text/javascript" src="$ROOTPATH/jsroot/scripts/JSRoot.core.js"></script>
   <script><!--
     var SESSION_ID = "$SESSION_ID";
     var ROOTPATH = "$ROOTPATH";

--- a/src/templates/index-dqm.tmpl
+++ b/src/templates/index-dqm.tmpl
@@ -4,7 +4,7 @@
  <head
   ><meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1"
   /><meta name="keywords" content="CMS, DQM, data quality monitoring, histogram display"
-  /><script type="text/javascript" src="$ROOTPATH/jsroot/scripts/JSRootCore.js"></script>
+  /><script type="text/javascript" src="$ROOTPATH/jsroot/scripts/JSRoot.core.js"></script>
   <script><!--
     var SESSION_ID = "$SESSION_ID";
     var ROOTPATH = "$ROOTPATH";

--- a/src/templates/index.tmpl
+++ b/src/templates/index.tmpl
@@ -4,7 +4,7 @@
  <head
   ><meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1"
   /><meta name="keywords" content="CMS, DQM, data quality monitoring, histogram display"
-  /><script type="text/javascript" src="$ROOTPATH/jsroot/scripts/JSRootCore.js"></script>
+  /><script type="text/javascript" src="$ROOTPATH/jsroot/scripts/JSRoot.core.js"></script>
   <script><!--
     var SESSION_ID = "$SESSION_ID";
     var ROOTPATH = "$ROOTPATH";


### PR DESCRIPTION
This PR is part of the effort to update the JSROOT version used by the DQMGUI (currently v5), which is missing some of the features requested by the users (https://indico.cern.ch/event/1616925/contributions/6813409/attachments/3183759/5664182/ops_news_01_12_2025.pdf#page=8).

The only breaking change seems to be the filename of the main `.js` file: https://github.com/root-project/jsroot/blob/master/docs/JSROOT.md#migration-v5---v6