### PR TITLE
Reduce LRU image cache's memory footprint

### DIFF
--- a/src/cpp/DQM/serverext.cc
+++ b/src/cpp/DQM/serverext.cc
@@ -1229,6 +1229,23 @@ class VisDQMRenderLink {
     int height;
     int inuse;
     bool busy;
+
+    void assignWithoutDatabytes(const Image &other) {
+      id = other.id;
+      hash = other.hash;
+      version = other.version;
+      flags = other.flags;
+      tag = other.tag;
+      pathname = other.pathname;
+      imagespec = other.imagespec;
+      qdata = other.qdata;
+      pngbytes = other.pngbytes;
+      numparts = other.numparts;
+      width = other.width;
+      height = other.height;
+      inuse = other.inuse;
+      busy = other.busy;
+    }
   };
 
   Filename dir_;
@@ -1809,14 +1826,13 @@ private:
       assert(!img.busy);
       assert(!img.inuse);
       assert(img.pngbytes.empty());
-      img = proto;
+      img.assignWithoutDatabytes(proto);
       img.busy = true;
       img.inuse++;
 
       // If we are not rescaling, request and compress image.
       if (width == protoreq.width && height == protoreq.height) {
         requestimg(img, proto.databytes, srcbytes);
-        std::string().swap(img.databytes);
       }
       // Otherwise, we are rescaling. First get original bigger image,
       // then rescale and compress the image. We might either find the
@@ -1830,11 +1846,10 @@ private:
           assert(!srcimg.busy);
           assert(!srcimg.inuse);
           assert(srcimg.pngbytes.empty());
-          srcimg = protoreq;
+          srcimg.assignWithoutDatabytes(protoreq);
           srcimg.busy = true;
           srcimg.inuse++;
           requestimg(srcimg, protoreq.databytes, srcbytes);
-          std::string().swap(srcimg.databytes);
           assert(srcimg.inuse > 0);
           assert(srcimg.busy);
           srcimg.busy = false;

--- a/src/cpp/DQM/serverext.cc
+++ b/src/cpp/DQM/serverext.cc
@@ -1512,7 +1512,7 @@ private:
     for (int i = 0; i < IMAGE_CACHE_SIZE; ++i) {
       if (cache_[i].id && cache_[i].hash == proto.hash &&
           cache_[i].width == proto.width && cache_[i].height == proto.height &&
-          cache_[i].databytes == proto.databytes &&
+          //   cache_[i].databytes == proto.databytes &&
           cache_[i].qdata == proto.qdata &&
           cache_[i].pathname == proto.pathname &&
           cache_[i].imagespec == proto.imagespec) {
@@ -1563,9 +1563,10 @@ private:
       f << i->second << ' ' << i->first << std::endl;
   }
 
-  void requestimg(Image &img, std::string &imgbytes, const bool json = false,
+  void requestimg(Image &img, const std::string &databytes_in,
+                  std::string &imgbytes_out, const bool json = false,
                   const bool jsroot = false) {
-    assert(imgbytes.empty());
+    assert(imgbytes_out.empty());
 
     // Pick the least loaded server to talk to.  While we do that,
     // check the servers are still running; restart those that are
@@ -1662,7 +1663,7 @@ private:
 
       uint32_t words[11] = {(uint32_t)(sizeof(words) + img.pathname.size() +
                                        img.imagespec.size() +
-                                       img.databytes.size() + img.qdata.size()),
+                                       databytes_in.size() + img.qdata.size()),
                             msg_type,
                             img.flags,
                             img.tag,
@@ -1671,7 +1672,7 @@ private:
                             (uint32_t)img.numparts,
                             (uint32_t)img.pathname.size(),
                             (uint32_t)img.imagespec.size(),
-                            (uint32_t)img.databytes.size(),
+                            (uint32_t)databytes_in.size(),
                             (uint32_t)img.qdata.size()};
 
       std::string message;
@@ -1679,7 +1680,7 @@ private:
       message.append((const char *)&words[0], sizeof(words));
       message.append(img.pathname);
       message.append(img.imagespec);
-      message.append(img.databytes);
+      message.append(databytes_in);
       message.append(img.qdata);
       sock.xwrite(&message[0], message.size());
       message.clear();
@@ -1691,7 +1692,7 @@ private:
            words[1] == DQM_REPLY_JSROOT_DATA)) {
         message.resize(words[0] - 2 * sizeof(uint32_t), '\0');
         if (sock.xread(&message[0], message.size()) == message.size())
-          imgbytes = message;
+          imgbytes_out = message;
       }
     } catch (Error &e) {
       logme() << "ERROR: failed to retrieve image: " << e.explain()
@@ -1707,11 +1708,11 @@ private:
     if (sock.fd() == IOFD_INVALID)
       srv.pending.clear();
     else {
-      if (!imgbytes.empty()) {
+      if (!imgbytes_out.empty()) {
         srv.checkme = false;
         srv.lastimg.clear();
         if (msg_type == DQM_MSG_GET_IMAGE_DATA)
-          compress(img, imgbytes);
+          compress(img, imgbytes_out);
       }
       srv.pending.pop_front();
     }
@@ -1813,9 +1814,10 @@ private:
       img.inuse++;
 
       // If we are not rescaling, request and compress image.
-      if (width == protoreq.width && height == protoreq.height)
-        requestimg(img, srcbytes);
-
+      if (width == protoreq.width && height == protoreq.height) {
+        requestimg(img, proto.databytes, srcbytes);
+        std::string().swap(img.databytes);
+      }
       // Otherwise, we are rescaling. First get original bigger image,
       // then rescale and compress the image. We might either find the
       // original as-is, in which case we need to expand the PNG form,
@@ -1831,7 +1833,8 @@ private:
           srcimg = protoreq;
           srcimg.busy = true;
           srcimg.inuse++;
-          requestimg(srcimg, srcbytes);
+          requestimg(srcimg, protoreq.databytes, srcbytes);
+          std::string().swap(srcimg.databytes);
           assert(srcimg.inuse > 0);
           assert(srcimg.busy);
           srcimg.busy = false;
@@ -1889,8 +1892,7 @@ private:
     assert(img.pngbytes.empty());
     img.busy = true;
     img.inuse++;
-    requestimg(img, jsonData, !jsroot, jsroot);
-
+    requestimg(img, proto.databytes, jsonData, !jsroot, jsroot);
     assert(img.inuse > 0);
     assert(img.busy);
     img.busy = false;
@@ -2681,8 +2683,8 @@ public:
     // FIXME: from client: buildStreamerInfo(streamers_);
     pthread_rwlock_init(&itemlock_, 0);
     pthread_cond_init(&reqrecv_, 0);
-    logme() << "INFO: DQM live thread started"
-            << ", listening for data from " << host << ":" << port << "\n";
+    logme() << "INFO: DQM live thread started" << ", listening for data from "
+            << host << ":" << port << "\n";
 
     debug(verbose);
     delay(500);


### PR DESCRIPTION
Investigating #41, we found that the high memory usage is stemming from the `lruimg` cache kept by the server, which keeps the last 1024 rendered images in memory. 

This cache stores, among other things, the `databytes` of the histogram used to render the image. Upon investigation, it looks like these are not strictly needed, nor reused, unlike the `pngbytes`, which store the actual rendered image.  This PR modifies the logic to clear the `databytes` of the cached images completely, trying to reduce overall memory usage. 


>[!WARNING]
	One other thing to note is that, the changes introduced by the PR also affect the way that the cache hit check is done ([here](https://github.com/cms-DQM/dqmgui_prod/pull/46/changes#diff-7dcec13b41048353e20dfe2ace3700bd5b1809af45bc4aad213a13bb718f81f6L1515)): `databytes` are no longer considered during this check, as they will be empty. This should not, in general, affect the cache performance. One corner case scenario that _will_ affect its correctness, however, will be the following:
	1. A histogram is rendered and cached in the LRU cache. 
	2. The same histogram is updated in the DQMGUI's index, e.g., by uploading a newer file containing the same histogram. The cache still contains the previous version of the histogram at this point.
	3.  The user requests a refresh of the page containing the histogram. The cache checks whether the histogram is already rendered, and does not consider the updated `databytes`, which are due to the new version of the histogram, giving a false cache hit, and returns the cached, older version of the histogram. 


Tests were done with:
- An exceptionally huge ROOT histogram which, when unpacked, reaches ~960 MB in memory. 
- `DQMNet`'s `MESSAGE_SIZE_LIMIT` increased to 1GB to accommodate the above change.
- `O0` optimization
- `valgrind --tool=massif --num-callers=500 --error-limit=no --trace-children=yes --suppressions=/data/srv/root/v6-28-10/etc/valgrind-root.supp --suppressions=/data/srv/root/v6-28-10/etc/valgrind-root-python.supp --suppressions=/usr/libexec/valgrind/default.supp --vgdb=yes`

## Further optimizations (TODO?):

- [ ] Prevent loading the data from the index before rendering, unless the histogram actually needs to be rendered, avoiding unnecessary mem usage spikes, when the historgams are in cache. 

## Performance

### Baseline memory usage

<img width="2428" height="1626" alt="image" src="https://github.com/user-attachments/assets/6209ffdb-61af-4209-8771-743ae7dbf331" />

### With the PR

<img width="2428" height="1626" alt="image" src="https://github.com/user-attachments/assets/41cce5de-ce63-4176-8b8c-ddfb7b71d418" />
