### PR TITLE
fix(index): restore sample metadata on re-import after removal

### DIFF
--- a/src/cpp/DQM/index.cc
+++ b/src/cpp/DQM/index.cc
@@ -1592,6 +1592,11 @@ static int addFiles(const Filename &indexdir, std::list<FileInfo> &files) {
             s.lastImportTime = now;
             s.sourceFileIdx = sapath.index();
             s.importVersion++;
+            s.numObjects = numObjs;
+            s.numEvents = numEvents;
+            s.numLumiSections = numLumiSections;
+            s.runStartTime = runStartTime;
+            s.processedTime = processedTime;
             extend(ix, s, samples.size() - 1, minfo, objnames, oldfiles,
                    newfiles, streamFile | streampbFile, rootobjs);
             datafile[0] = s.files[0];


### PR DESCRIPTION
When addFiles matched an existing sample for in-place update, it omitted updating numObjects, numEvents, numLumiSections, runStartTime, and processedTime. After a visDQMIndex remove, the sample's numObjects is set to 0; without this fix a subsequent re-import wrote the data correctly to disk but left numObjects=0 in the master record, causing the server to skip the sample and making the newly imported run invisible in the GUI.

More info at https://gitlab.cern.ch/cms-ppd/technical-support/ts-coordination/-/work_items/93